### PR TITLE
Fix coco format converter

### DIFF
--- a/coco-format-conversion/README.md
+++ b/coco-format-conversion/README.md
@@ -6,7 +6,7 @@ This script converts the Manga109 XML annotations to MSCOCO's JSON format.
 Run the following command to execute the conversion. For the `--manga109-root-dir` option, specify the path to the Manga109 dataset root directory (not the "annotations" directory).
 
 ```bash
-python coco_format_conversion.py --manga109-root-dir YOUR_DIR/Manga109_YYYY_MM_DD --output-dir [out-dir] --train-val-cutoff [cutoff_ratio] --val-test-cutoff [cutoff_ratio]
+python coco_format_conversion.py YOUR_DIR/Manga109_YYYY_MM_DD --outpath [out-dir] --train-val-cutoff [cutoff_ratio] --val-test-cutoff [cutoff_ratio]
 ```
 
 The training-validation cutoff and validation-testing cutoff are set to 0.8 and 0.9 by default, repsectively.

--- a/coco-format-conversion/coco_format_conversion.py
+++ b/coco-format-conversion/coco_format_conversion.py
@@ -78,8 +78,8 @@ def images_annotations(manga109_root_dir, train_val_cutoff, val_test_cutoff):
              val_test_cutoff else ret_images_test).append(image)
 
         # Annotations
-        frame_bb_list = tuple(bb_iter(title, manga109_root_dir, categories=[d["name"] for d in d_categories]))
-        for i_id, (i_page, i_category, bb) in enumerate(frame_bb_list):
+        bb_list = tuple(bb_iter(title, manga109_root_dir, categories=[d["name"] for d in d_categories]))
+        for i_id, (i_page, i_category, bb) in enumerate(bb_list):
             bb_id = i_id + annotation_id_base
             image_id = i_page + image_id_base
             p1 = bb["@xmin"], bb["@ymin"]

--- a/coco-format-conversion/coco_format_conversion.py
+++ b/coco-format-conversion/coco_format_conversion.py
@@ -78,7 +78,7 @@ def images_annotations(manga109_root_dir, train_val_cutoff, val_test_cutoff):
              val_test_cutoff else ret_images_test).append(image)
 
         # Annotations
-        frame_bb_list = tuple(bb_iter(title, manga109_root_dir, categories=["frame"]))
+        frame_bb_list = tuple(bb_iter(title, manga109_root_dir, categories=[d["name"] for d in d_categories]))
         for i_id, (i_page, i_category, bb) in enumerate(frame_bb_list):
             bb_id = i_id + annotation_id_base
             image_id = i_page + image_id_base

--- a/coco-format-conversion/coco_format_conversion.py
+++ b/coco-format-conversion/coco_format_conversion.py
@@ -167,5 +167,7 @@ if __name__ == "__main__":
 
     for outname, data_dict in zip(["train", "val", "test"], [data_training, data_val, data_test]):
         coco_json = json.dumps(data_dict)
+        print(f"Writing data for {outname}...")
         with (args.outpath / "instances_{}.json".format(outname)).open("wt") as f:
             f.write(coco_json)
+    print("Done.")


### PR DESCRIPTION
This pull request fixes three things:

- There was a bug that only the `frame` category was included in the output data. The first commit fixes this so that all four categories are included.
- Some parts of the example command in the usage README was wrong. The second commit fixes this.
- Some runtime messages are added to indicate when the data is being written (which takes a little bit of time). This is also included in the second commit.